### PR TITLE
Handle bus states subscription cleanup in arm dashboard

### DIFF
--- a/src/app/arm-dashboard/arm-dashboard.component.ts
+++ b/src/app/arm-dashboard/arm-dashboard.component.ts
@@ -1,5 +1,6 @@
 
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { JointState } from '../models';
 import { CanBridgeService } from '../can-bridge.service';
 import { ArmAccordionComponent } from '../arm-accordion/arm-accordion.component';
@@ -28,8 +29,10 @@ import { ThreeViewerComponent } from '../three-viewer/three-viewer.component';
   </div>
   `
 })
-export class ArmDashboardComponent implements OnInit{
+export class ArmDashboardComponent implements OnInit, OnDestroy{
   states: Record<number, JointState> = {};
+  sub: Subscription = new Subscription();
   constructor(public bus: CanBridgeService) {}
-  ngOnInit(){ this.bus.connect(); this.bus.states$.subscribe(s=> this.states = s); }
+  ngOnInit(){ this.bus.connect(); this.sub = this.bus.states$.subscribe(s=> this.states = s); }
+  ngOnDestroy(){ this.sub.unsubscribe(); }
 }


### PR DESCRIPTION
## Summary
- Import `OnDestroy` and `Subscription` in `arm-dashboard` component
- Save `bus.states$` subscription and unsubscribe in `ngOnDestroy`

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68966002b078833292a4743b544ee2b8